### PR TITLE
debug portforwarding wsl ip addr command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Windows Subsystem for Linux (WSL) is a powerful feature that allows you to run a
 1. Open PowerShell as Administrator on Windows.
 2. Get your WSL IP address and set up port forwarding:
    ``` powershell
-   netsh interface portproxy add v4tov4 listenport=2222 listenaddress=0.0.0.0 connectport=2222 connectaddress=$((wsl hostname -i).trim())
+   netsh interface portproxy add v4tov4 listenport=2222 listenaddress=0.0.0.0 connectport=2222 connectaddress=$((wsl hostname -I).trim())
    ```
 
 ## Step 3: Configure Windows Firewall


### PR DESCRIPTION
The command option should be `-I` (Capital I) instead of `-i` (small i).

Ref: 
- https://github.com/MicrosoftDocs/WSL/issues/1834
- https://learn.microsoft.com/en-us/windows/wsl/networking#accessing-a-wsl-2-distribution-from-your-local-area-network-lan